### PR TITLE
Configure CircleCI to push to production

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,9 @@
 machine:
   node:
     version: 4.1.0
+
+deployment:
+  production:
+    branch: master
+    commands:
+      - git push git@vm344b.se.rit.edu/usr/local/indoor-umbrellas


### PR DESCRIPTION
When code is merged to master, CircleCI _should_ push to the server.
The server is configured to accept the code and then restart the server

Closes #8
Closes #25
