### PR TITLE
Protect the `/api` endpoints with authentication

### DIFF
--- a/server.js
+++ b/server.js
@@ -100,7 +100,7 @@ server.get('/', ensureAuthenticated, function (req, res) {
 
 server.use('/', express.static('dist'));
 
-server.use('/api', api);
+server.use('/api', ensureAuthenticated, api);
 
 //Chat server 
 var chatServer = http.createServer(server);


### PR DESCRIPTION
Any request made to an `/api` endpoint must have a valid session
associated with it.
