### PR TITLE
fixed the time display on front page

### DIFF
--- a/app/js/components/event.js
+++ b/app/js/components/event.js
@@ -2,8 +2,9 @@ import React, { Component } from 'react';
 
 export default class Event extends Component {
   render() {
-    var dateString = `${this.props.startDateTime} ${(this.props.endDateTime ? `- ${this.props.endDateTime}` : "")}`;
-
+    var startTime = new Date(this.props.startDateTime);
+    var endTime = new Date(this.props.endDateTime);
+    var dateString = `${startTime.toLocaleTimeString()} - ${endTime.toLocaleTimeString()}`
     return (
       <div className="panel panel-primary">
         <div className="panel-heading">


### PR DESCRIPTION
Looks like this now:
![image](https://cloud.githubusercontent.com/assets/326557/11140190/ca69b172-89a5-11e5-8b43-77347ce146de.png)
