### PR TITLE
Implement the UI for purchasing stocks

### DIFF
--- a/app/js/components/dismissible-alert.js
+++ b/app/js/components/dismissible-alert.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+class DismissibleAlert extends React.Component {
+  componentDidMount() {
+    $(this.div).on('close.bs.alert', this.props.onDismiss);
+  }
+
+  render() {
+    return (
+      <div className={`alert alert-${this.props.alertType} alert-dismissible`}
+          role="alert" ref={(r) => this.div = r}>
+        <button type="button" className="close" data-dismiss="alert"
+            aria-label="Close"><span aria-hidden="true">×</span></button>
+
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+DismissibleAlert.propTypes = {
+  onDismiss: React.PropTypes.func,
+  alertType: React.PropTypes.string
+}
+
+export default DismissibleAlert;

--- a/app/js/components/stock-transaction-panel.js
+++ b/app/js/components/stock-transaction-panel.js
@@ -1,0 +1,103 @@
+import React from 'react';
+import {REQUEST_SUCCESSFUL, REQUEST_FAILURE, NO_REQUEST} from '../constants';
+import DismissibleAlert from './dismissible-alert';
+
+class StockTransactionPanel extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {ajaxSuccess: NO_REQUEST}
+  }
+
+  performTransaction(action) {
+    const transaction = {
+      symbol: this.props.stock.dataset.dataset_code,
+      delta: this.shareCount.value,
+      price: this.props.stock.dataset.data[0][1],
+      note: null
+    };
+
+    switch (action) {
+      case 'SELL':
+        transaction.delta *= -1;
+        break;
+      case 'BUY':
+        break;
+    }
+
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', '/api/stocks/transactions');
+    xhr.setRequestHeader('Content-Type', 'application/json');
+    
+    xhr.onload = () => {
+      this.shareCount.value = '';
+      this.setState({...this.state, ajaxSuccess: xhr.status == 200 ?
+                                                 REQUEST_SUCCESSFUL :
+                                                 REQUEST_FAILURE});
+    };
+
+    xhr.send(JSON.stringify({transaction}));
+  }
+
+  sellStock() {
+    this.performTransaction('SELL');
+  }
+
+  buyStock() {
+    this.performTransaction('BUY');
+  }
+
+  render() {
+    // don't do anything if no stock or it's an error
+    if (this.props.stock == null || this.props.stock.quandl_error) {
+      return <div />;
+    }
+
+    return (
+      <div>
+        <button onClick={this.sellStock.bind(this)}>
+          Sell Shares
+        </button>
+        <input type='number' min='0' ref={(r) => this.shareCount = r} />
+        <button onClick={this.buyStock.bind(this)}>
+          Buy Shares
+        </button>
+
+        {this.renderAlert()}
+      </div>
+    );
+  }
+  
+  renderAlert() {
+    var content;
+
+    const fn = () => this.setState({...this.state, ajaxSuccess: NO_REQUEST});
+
+    switch (this.state.ajaxSuccess) {
+      case REQUEST_SUCCESSFUL:
+        content = (
+          <DismissibleAlert onDismiss={fn} alertType='success'>
+            Transaction successful
+          </DismissibleAlert>
+        );
+        break;
+      case REQUEST_FAILURE:
+        content = (
+          <DismissibleAlert onDismiss={fn} alertType='danger'>
+            Transaction not successful
+          </DismissibleAlert>
+        );
+        break;
+      default:
+        content = <div />
+        break;
+    }
+
+    return content;
+  }
+}
+
+StockTransactionPanel.propTypes = {
+  stock: React.PropTypes.object
+}
+
+export default StockTransactionPanel;

--- a/app/js/constants/index.js
+++ b/app/js/constants/index.js
@@ -1,0 +1,3 @@
+export const REQUEST_SUCCESSFUL = 1;
+export const REQUEST_FAILURE = 0;
+export const NO_REQUEST = -1;

--- a/app/js/stocks.js
+++ b/app/js/stocks.js
@@ -6,6 +6,7 @@ import StockSearchBar from './components/stock-search-bar';
 import StockDetails from './components/stock-details';
 import StockPlot from './components/stock-plot';
 import Chat from './components/chat';
+import StockTransactionPanel from './components/stock-transaction-panel';
 
 import {getStockData} from './util/stock-utils';
 
@@ -31,8 +32,15 @@ class App extends React.Component {
       <div>
         <Navbar page="Stocks"/>
         <div className="container">
-          <StockSearchBar onSearch={this.handleSymbolChange.bind(this)} />
-          <StockDetails stock={this.state.stock}/>
+          <div className="row">
+            <StockSearchBar onSearch={this.handleSymbolChange.bind(this)} />
+          </div>
+          <div className="row">
+            <StockTransactionPanel stock={this.state.stock} />
+          </div>
+          <div className="row">
+            <StockDetails stock={this.state.stock}/>
+          </div>
         </div>
         <Chat />
       </div>


### PR DESCRIPTION
Provides a simple UI for purchasing stocks.  Includes success/failure messages that show whether or not the the transaction was successful.

This is the first pass at it and it can be cleaned up (both visually and for usability).  A nice to have would be how many stocks of a particular company you own being displayed when you go to sell stocks.
<img width="808" alt="screen shot 2015-11-22 at 4 20 59 pm" src="https://cloud.githubusercontent.com/assets/732753/11326333/0bbb7eb2-9135-11e5-976a-fb7c4941e018.png">
